### PR TITLE
[BOJ] 2470_두용액 / 골드5 / 1시간 / O

### DIFF
--- a/week1/BOJ_2470/두용액_홍지훈.py
+++ b/week1/BOJ_2470/두용액_홍지훈.py
@@ -1,0 +1,29 @@
+import sys, bisect
+
+N = int(sys.stdin.readline().rstrip())
+nums = list(map(int, sys.stdin.readline().rstrip().split()))
+
+# 오름차순 정렬
+nums.sort()
+
+# 투포인터
+start, end = 0, N - 1
+
+# 최소쌍
+result = []
+# 최소합
+sum = 2000000000
+
+# 두 포인터로 0에 가장 가까울 경우
+while (start < end):
+  currentSum = abs(nums[start] + nums[end])
+  if currentSum < sum:
+    sum = currentSum
+    result = [nums[start], nums[end]]
+  if nums[start] + nums[end] < 0:
+    start += 1
+  else:
+    end -= 1
+
+
+print(result[0], result[1])


### PR DESCRIPTION
### 📖 풀이한 문제

- 백준2470-두용액

### ⭐️ 문제에서 주로 사용한 알고리즘

`정렬`, `두 포인터`

> `이분 탐색` 을 어디에 사용하는 문제였을까요..? 생각이 안나서 정렬과 두 포인터만 사용했습니다..

### 대략적인 코드 설명

- 두 포인터를 보고 먼저 오름차순 정렬한 뒤, 앞, 뒤에 포인터를 2개 배치하고 두 인덱스의 숫자 합의 절댓값이 이전 합보다 작으면 갱신하고
- 두 수의 합이 0보다 작으면 합을 키우기 위해 start 를 1 증가, 0 보다 크면 end 를 1 감속시켰습니다.

> 원래 `이분 탐색` 을 통해 0보다 작은 배열, 0보다 큰 배열을 만든뒤, 각각의 그룹에서 0에 가까운 두 수의 합을 앞에서의 알고리즘에서 구한 합과 비교하는 로직도 넣었는데 시간초과를 겪은 뒤 앞의 알고리즘만으로 충분하다고 생각되어 제거했습니다