### PR TITLE
[BOJ] 2504_괄호의값 / 골드5 / 110분 / O

### DIFF
--- a/week2/BOJ_2504/괄호의값_홍지훈.py
+++ b/week2/BOJ_2504/괄호의값_홍지훈.py
@@ -1,0 +1,46 @@
+# 구현, 자료구조, 스택
+
+import sys
+
+inputStr = sys.stdin.readline().rstrip()
+dic = {'(':')','[':']'}
+stack = []
+temp = 1
+sum = 0
+check = True
+
+for char in inputStr:
+  
+  # 여는 괄호라면 스택에 추가
+  if char in dic: 
+    check = True
+    stack.append(char) 
+    if char == '(': temp *= 2 # ( 는 항상 * 2
+    else: temp *= 3 # [ 는 항상 * 3
+
+  # 닫는 괄호일 경우
+  else:
+    if not stack:
+      sum = 0
+      break
+    last = stack.pop()
+    # 닫는 쌍이 맞는 경우
+    if dic[last] == char:
+      if check:  # 바로 이전까지 여는 괄호였을 경우에만 sum 에 더한다.
+        sum += temp
+        check = False 
+
+      if char == ')': # ) 는 그때까지의 temp 를 sum 에 더하고 temp 를 2 로 나눈다.
+        temp //= 2 
+      elif char == ']': # ] 는 그때까지의 temp 를 sum 에 더하고 temp 를 3 으로 나눈다.
+        temp //= 3
+
+    # 닫는 괄호만 있었을 경우, 여는 괄호와 닫는 괄호 쌍이 맞지 않는 경우
+    elif len(stack) == 0 or dic[last] != char:
+      sum = 0
+      break
+
+if stack:
+  print(0)
+else:
+  print(sum)


### PR DESCRIPTION
### 📖 풀이한 문제

- 백준 2504-괄호의값

### ⭐️ 문제에서 주로 사용한 알고리즘

`스택`, `딕셔너리`

### 대략적인 코드 설명

- 올바른 괄호 쌍을 딕셔너리로 key: value 형태에 여는 괄호: 닫는 괄호로 생성한다.
- 만약 키에 해당하는 여는 괄호가 char 이라면 stack 에 append 를 한다.
- 여는 괄호의 경우 `(` 는 x 2, `[` 는 x 3 을 `temp` 라는 임시 변수에 곱한다.
- 닫는 괄호의 경우 스택에 아무것도 없다면 ( `여는 괄호가 아직 없다면` ) 종료하고 합계를 0으로 초기화한다.
- 닫는 괄호가 바로 이전까지가 여는 괄호였을 경우에만 현재까지 곱해진 `temp` 를 sum 에 더한다.
- 만약 닫는 괄호가 나오면 `)` 는 temp 에 `2` 를 나누고 `]` 는 temp 에 `3` 을 나눕니다.
- 이는 닫는 괄호가 나오는 순간 그 전까지가 여는 괄호였다면 이후 연산에 상관없이 곱한 값을 sum 에 더하는 것에 영향이 없기 때문에 확정적으로 더해지는 순간을 `닫는 괄호가 나오고 그 전까지가 여는 괄호였을 경우` 로 둔다.