### PR TITLE
[BOJ] 1260_DFS와 BFS / 실버2 / 30분 / O

### DIFF
--- a/week5/BOJ_1260/DFS와 BFS_홍지훈.py
+++ b/week5/BOJ_1260/DFS와 BFS_홍지훈.py
@@ -1,0 +1,65 @@
+import sys
+from collections import deque
+
+# N : 정점의 개수, M : 간선의 개수, V : 탐색을 시작할 정점의 번호
+N, M, V = list(map(int,sys.stdin.readline().rstrip().split()))
+
+# M 개 줄에 간선이 연결하는 두 정점의 번호
+edges = [ tuple(map(int,sys.stdin.readline().rstrip().split())) for _ in range(M)]
+
+def create_adjacency_list(pairs):
+  adjacency_list = {}
+
+  for pair in pairs:
+    node1, node2 = pair
+    if node1 not in adjacency_list:
+      adjacency_list[node1] = []
+    if node2 not in adjacency_list:
+      adjacency_list[node2] = []
+    
+    adjacency_list[node1].append(node2)
+    adjacency_list[node2].append(node1)
+
+  for key in adjacency_list:
+    adjacency_list[key].sort()
+
+  return adjacency_list
+
+def dfs(graph, start, visited):
+  if start not in graph.keys():
+    return
+  if start not in visited:
+    visited.append(start)
+
+    for neighbor in graph[start]:
+      if neighbor not in visited:
+        dfs(graph, neighbor, visited)
+
+def bfs(graph, start, visited):
+  if start not in graph.keys():
+    return
+  queue = deque([start])
+  while queue:
+    cur_v = queue.popleft()
+    if cur_v not in visited:
+      visited.append(cur_v)
+    for node in graph[cur_v]:
+      if node not in visited:
+        visited.append(node)
+        queue.append(node)
+
+graph = create_adjacency_list(edges)
+dfs_visited = []
+bfs_visited = []
+
+dfs(graph, V, dfs_visited)
+bfs(graph, V, bfs_visited)
+
+if not dfs_visited:
+    dfs_visited = [V]
+
+if not bfs_visited:
+    bfs_visited = [V]
+
+print(*dfs_visited)
+print(*bfs_visited)


### PR DESCRIPTION
### 📖 풀이한 문제

- 백준 1260-DFS와 BFS

### ⭐️ 문제에서 주로 사용한 알고리즘

`DFS`, `BFS`

### 대략적인 코드 설명

- 둘다 인접 노드 쌍의 엣지만 주어졌으니 이를 인접 리스트 형태의 graph 를 만들고 노드쌍을 숫자가 작은 순서대로 방문해야 하니 sort 처리
- dfs 의 경우 인접 노드중 방문하지 않은 노드가 있다면 해당 인접 노드에서 dfs 를 재귀
- bfs 의 경우 deque 으로 큐를 만들어 둔다. 시작점을 큐에 넣은 뒤, 큐에서 하나씩 popleft() 시킬때 해당 노드를 기준으로 인접 노드중 방문하지 않은 모든 노드를 큐에 넣고 하나씩 방문한다. 이 과정을 큐가 빌 때까지 반복한다. 