### PR TITLE
[BOJ] 2178_미로 탐색 / 실버1 / 60분 / O

### DIFF
--- a/week5/BOJ_2178/미로 탐색_홍지훈.py
+++ b/week5/BOJ_2178/미로 탐색_홍지훈.py
@@ -1,0 +1,30 @@
+import sys
+input = sys.stdin.readline
+from collections import deque
+
+# N * M 행렬의 미로
+N, M = list(map(int,input().rstrip().split()))
+
+maze = [ list(map(int,input().rstrip())) for _ in range(N)]
+
+dx = [0, 0, -1, 1]
+dy = [-1, 1, 0, 0]
+
+def bfs(y, x):
+  queue = deque()
+  queue.append((y, x))
+  while queue:
+    y, x = queue.popleft()
+    for i in range(4):
+      newX = x + dx[i]
+      newY = y + dy[i]
+      if newX < 0 or newY < 0 or newX >= M or newY >= N:
+        continue
+      if maze[newY][newX] == 0:
+        continue
+      if maze[newY][newX] == 1:
+        maze[newY][newX] = maze[y][x] + 1
+        queue.append((newY, newX))
+  return maze[N - 1][M - 1]
+
+print(bfs(0, 0))


### PR DESCRIPTION
### 📖 풀이한 문제

- 백준 2178-미로 탐색

### ⭐️ 문제에서 주로 사용한 알고리즘

`bfs`

### 대략적인 코드 설명

- 미로의 4방향을 두고 다음 노드가 갈 수 없는 노드라면 continue
- 다음 노드가 1이라면 아직 방문하지 않은 노드이니 이전 노드 값에서 1을 증가시켜 이동거리를 누적한다.
- 최종 노드의 위치값 (이동거리) 를 구한다.