### PR TITLE
[BOJ] 7576_토마토 / 골드5 / 110분 / O

### DIFF
--- a/week5/BOJ_7576/토마토_홍지훈.py
+++ b/week5/BOJ_7576/토마토_홍지훈.py
@@ -1,0 +1,47 @@
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+def bfs():
+    global fresh_tomatoes
+    if not contain_not_ripen():
+        return 0
+
+    count = 0
+    while queue:
+        lenQ = len(queue)
+        for _ in range(lenQ):
+            y, x = queue.popleft()
+            for i in range(4):
+                ny = y + dy[i]
+                nx = x + dx[i]
+                if 0 <= ny < N and 0 <= nx < M and tomato[ny][nx] == 0:
+                    tomato[ny][nx] = 1
+                    queue.append((ny, nx))
+                    fresh_tomatoes -= 1  # 새로 익은 토마토 갯수 갱신
+        count += 1
+        if fresh_tomatoes == 0:
+            return count
+
+def contain_not_ripen():
+    return fresh_tomatoes > 0
+
+# M : 상자의 가로 칸 수
+# N : 상자의 세로 칸 수
+M, N = map(int, input().rstrip().split())
+tomato = [list(map(int, input().rstrip().split())) for _ in range(N)]
+
+# 상, 하, 좌, 우
+dy = [-1, 1, 0, 0]
+dx = [0, 0, 1, -1]
+
+queue = deque((r, c) for r in range(N) for c in range(M) if tomato[r][c] == 1)
+fresh_tomatoes = sum(row.count(0) for row in tomato)  # 익지 않은 토마토 갯수 초기화
+
+count = bfs()
+
+if fresh_tomatoes > 0:
+    count = -1
+
+print(count)


### PR DESCRIPTION
### 📖 풀이한 문제

- 백준 7576-토마토

### ⭐️ 문제에서 주로 사용한 알고리즘

`bfs`

### 대략적인 코드 설명

- bfs 에서 각 level ( 시작점으로부터의 거리 ) 마다 큐에 담아 익을 수 있는 토마토인지 확인한다.
- 먼저 익어있는 토마토를 level 0 로 보기 위해 먼저 queue 에 append 한다
- 익지 않은 토마토의 개수를 업데이트하면서 더이상 익을 수 없는 토마토가 존재하는지 여부를 비교한다.
- bfs 를 다 돌았으나 아직 싱싱한 토마토가 남아있다면 -1 을 출력하고 처음부터 싱싱한 토마토가 없었다면 ( 다 익은 상태 ) 0 을 출력한다.

> PyPy3 는 통과되는데 Python3 는 시간초과가 떠서 그걸 해결하는데 시간이 좀 걸렸습니다..
원래 코드에서는 매 큐를 반복할 때마다 싱싱한 토마토가 남아있는지 수를 구했는데 싱싱한 토마토의 수를 먼저 구하고 익게 할 때마다 -1 씩 해주는 방식으로 바꾸니 통과되네요

#### 예시 - 큐를 반복할 때마다 싱싱한 토마토의 수를 구해서 시간초과가 뜨는 코드
```py
def bfs():
  if not contain_not_ripen():
     return 0

  count = 0
  while queue:
    if not contain_not_ripen():
       return count
    lenQ = len(queue)
    for _ in range(lenQ):
      y, x = queue.popleft()
      for i in range(4):
        ny = y + dy[i]
        nx = x + dx[i]
        if 0 <= ny < N and 0 <= nx < M and tomato[ny][nx] == 0:
          tomato[ny][nx] = 1
          queue.append((ny, nx))
    count += 1
    if not contain_not_ripen():
            return count

def contain_not_ripen():
    return any(0 in row for row in tomato)
```

#### 예시 - 싱싱한 토마토의 수를 먼저 구하고 매 큐마다 -1씩 갱신해주는 코드 (통과)
```py
def bfs():
    global fresh_tomatoes
    if not contain_not_ripen():
        return 0

    count = 0
    while queue:
        lenQ = len(queue)
        for _ in range(lenQ):
            y, x = queue.popleft()
            for i in range(4):
                ny = y + dy[i]
                nx = x + dx[i]
                if 0 <= ny < N and 0 <= nx < M and tomato[ny][nx] == 0:
                    tomato[ny][nx] = 1
                    queue.append((ny, nx))
                    fresh_tomatoes -= 1  # 새로 익은 토마토 갯수 갱신
        count += 1
        if fresh_tomatoes == 0:
            return count

def contain_not_ripen():
    return fresh_tomatoes > 0
```
