### PR TITLE
[BOJ] 11725_트리의 부모 찾기 / 실버2 / 80분 / O

### DIFF
--- a/week5/BOJ_11725/트리의 부모 찾기_이동혁.py
+++ b/week5/BOJ_11725/트리의 부모 찾기_이동혁.py
@@ -1,0 +1,24 @@
+N = int(input())
+adj_list = [[] for _ in range(N+1)]
+visited = [False] * (N+1)
+
+for _ in range(N-1):
+    u, v = map(int, input().split())
+    adj_list[u].append(v)
+    adj_list[v].append(u)
+
+def bfs(graph, v, visited):
+    parent_lst = [0] * (N+1)
+    queue = [v]
+    visited[v] = True
+    while queue:
+        current_v = queue.pop(0)
+        for i in graph[current_v]:
+            if not visited[i]:
+                parent_lst[i] = current_v
+                queue.append(i)
+                visited[i] = True
+    return parent_lst
+
+parent_lst = bfs(adj_list, 1, visited)
+print('\n'.join(map(str, parent_lst[2:])))


### PR DESCRIPTION
### 📖 풀이한 문제

- 백준 11725-트리의 부모 찾기

### ⭐️ 문제에서 주로 사용한 알고리즘

그래프, 인접리스트, BFS

### 대략적인 코드 설명

1260번 문제의 플로우를 거의 그대로 차용

1. 인접리스트와 방문한 노드 리스트 선언
2. 인접 리스트 완성
3. BFS: 리스트의 인덱스가 child 노드의 번호, 인덱스에 해당하는 값이 parent 노드의 번호가 되도록 하는 parent_lst 리스트와 코드를 추가
4. BFS를 수행한 결과 반환된 부모 노드의 리스트를 출력


