### PR TITLE
[PSG] 두 큐 합 같게 만들기 / Lv. 2 / 85분 / O

### DIFF
--- a/week7/두 큐 합 같게 만들기_양승혜.py
+++ b/week7/두 큐 합 같게 만들기_양승혜.py
@@ -1,0 +1,25 @@
+from collections import deque
+
+def solution(queue1, queue2):
+    sum1, sum2 = sum(queue1), sum(queue2)
+    q1, q2 = deque(queue1), deque(queue2)
+    count, maxcount = 0, len(queue1) * 3
+    
+    while True:
+        if sum1 > sum2:
+            num = q1.popleft()
+            q2.append(num)
+            count += 1
+            sum1 -= num
+            sum2 += num
+        elif sum1 < sum2:
+            num = q2.popleft()
+            q1.append(num)
+            count += 1
+            sum1 += num
+            sum2 -= num
+        else:
+            return count
+        
+        if count == maxcount:
+            return -1


### PR DESCRIPTION
### 📖 풀이한 문제
- 프로그래머스 - 두 큐 합 같게 만들기
### ⭐️ 문제에서 주로 사용한 알고리즘
- 큐
### 대략적인 코드 설명
1. pop(0)을 하면 시간 복잡도가 O(n)이 소요되기에 deque를 사용했다.
2. 각 큐의 합을 구하고, 큐의 합이 더 큰 쪽에서 작은 쪽으로 popleft()한 값을 append()한다.
3. 2번의 작업을 수행하면 count에 1을 더한다.
4. 만약 두 큐의 합이 같아지면 count를 리턴한다.
5. 하지만 count가 처음 큐의 길이 * 3이 되면 -1을 리턴한다.
 - len(queue) * 3 을 하는 이유 : 큐의 모든 원소들이 한 쪽으로 다 이동한 후 = len(queue), 다시 원래의 큐 길이 값으로 돌아오고(큐1과 큐2의 자리가 바뀐상태) = len(queue), 다시 반대 쪽으로 이동하는 동안 = len(queue) 에도 합이 같지 않으면 그 뒤엔 같은 숫자의 조합이 계속 반복된다. 따라서 len(queue) * 3을 한다. 
 - 하지만 len(queue) * 3 보다 1 ~3 정도 작은 값이 count의 최대 값인 것 같긴하다.. 하지만 거기까지는 자세히 밝혀낼 수 없기도하고, 1 ~ 3 개는 무의미한 수치라서 len(queue) * 3으로 간주했다.