### PR TITLE
[BOJ] 18352_특정 거리의 도시 찾기 / 실버2 / 50분 / O

### DIFF
--- a/week9/BOJ_18352/특정 거리의 도시 찾기_홍지훈.py
+++ b/week9/BOJ_18352/특정 거리의 도시 찾기_홍지훈.py
@@ -1,0 +1,38 @@
+import heapq
+import sys 
+input = sys.stdin.readline
+INF = int(1e9)
+
+N, M, K, X = map(int, input().split()) # N : 도시의 개수, M : 도로의 개수, K : 거리 정보, X : 출발 도시의 번호
+
+# 최단 거리를 기록할 answer
+answer = {node: INF for node in range(1, N + 1)}
+
+# 연결 리스트 graph
+graph = [[] for i in range(N + 1)]
+for _ in range(M):
+  A, B = map(int, input().split())
+  graph[A].append(B) # A 에서 B 로 가는 경로가 존재
+
+def dijkstra(start):
+  que = []
+  heapq.heappush(que, (0, start)) # 우선순위 큐 que 에 시작노드 start 까지의 최단 거리는 0이다.
+  answer[start] = 0
+  while que:
+    dist, now = heapq.heappop(que) # que 에 넣은 튜플 (dist, now) dist 는 거리, now 는 노드
+    if answer[now] < dist: # 갱신하지 않는 경우
+      continue
+    for next in graph[now]: # 현재 노드 now 에서 갈 수 있는 노드 next
+      new_dist = dist + 1
+      if new_dist < answer[next]:
+        answer[next] = new_dist
+        heapq.heappush(que, (new_dist, next))
+
+dijkstra(X)
+
+if K not in answer.values():
+  print(-1)
+else:
+  for i in range(1, N + 1):
+    if answer[i] == K:
+      print(i)


### PR DESCRIPTION
### 📖 풀이한 문제

- 백준 18352-특정 거리의 도시 찾기

### ⭐️ 문제에서 주로 사용한 알고리즘

`다익스트라 최단 경로`, `우선순위 큐`

### 대략적인 코드 설명

#### 다익스트라 최단 경로 알고리즘

`다익스트라 최단 경로 알고리즘` 은 그래프에 여러 개의 노드가 있을 때 특정한 노드에서 출발해 다른 노드로 가는 각각의 최단 경로를 구하는 알고리즘 입니다.

`알고리즘의 원리`
1. 출발 노드를 설정
2. 최단 거리 테이블 초기화
3. 방문하지 않은 노드 중 최단 거리가 가장 짧은 노드 선택
4. 해당 노드를 거쳐 다른 노드로 가는 비용 계산하여 최단 거리 테이블 갱신
5. 3~4 번 과정 반복

> 다익스트라 최단 경로 알고리즘의 특징
- 최단 경로를 구하는 과정에서 각 노드에 대한 현재까지의 최단 경로 정보를 항상 1차원 리스트에 저장하여 리스트를 갱신

만약 방문하지 않은 노드중 최단 거리가 가장 짧은 노드를 O(n) 으로 매번 탐색한다면 시간복잡도 측면에서 좋지 않습니다.
이 부분을 우선순위 큐를 통해 O(logn) 으로 줄일 수 있습니다.

#### 풀이 및 접근법

1. 초기 설정

최단 경로 알고리즘 문제를 풀기 위해 최단 거리를 갱신할 딕셔너리 `answer` 와 각 노드별 연결 관계를 나타낼 `graph` 를 생성합니다.

![스크린샷 2023-12-12 오후 8 32 01](https://github.com/Stendhalsynd/baekjoon-algorithm-study/assets/96957774/096a6797-0dec-4168-a105-338113026bde)

2. 다익스트라 알고리즘 

- 우선순위 큐에 튜플 형식으로 현재 노드에서 (거리, 다음 노드) 형식으로 큐에 넣습니다.
- 시작 노드에서 시작 노드까지는 항상 0입니다.
- 만약 우선순위 큐에 노드가 남아있다면 하나씩 꺼내서 현재 가리키고 있는 노드와 해당 노드까지의 거리를 구합니다.
- 만약 이렇게 구한 거리가 기존 answer 의 거리보다 크면 갱신하지 않습니다.
- 현재 노드에서 갈 수 있는 모든 노드까지 반복해서 탐색할때 거리는 1씩 늘어나는데 이 거리가 기존 answer 에 기록한 거리보다 짧다면 최단 경로를 갱신하고 갱신할 때마다 우선순위 큐에 해당 (갱신된 거리, 다음 노드) 형식의 튜플을 넣습니다.
- 거리가 동일하다면 노드번호가 작은 경우를 먼저 탐색합니다.

> 항상 현재 `시작 노드로부터 최단 거리에 있는 노드`를 우선순위 큐에서 뽑아 최단 경로를 갱신합니다.

![스크린샷 2023-12-12 오후 8 32 17](https://github.com/Stendhalsynd/baekjoon-algorithm-study/assets/96957774/13b89554-8fd1-4eca-b5a3-11f8bca4c6e2)

![스크린샷 2023-12-12 오후 8 32 31](https://github.com/Stendhalsynd/baekjoon-algorithm-study/assets/96957774/3c36931e-df2d-4ecb-a657-126217cdb5be)

![스크린샷 2023-12-12 오후 8 32 46](https://github.com/Stendhalsynd/baekjoon-algorithm-study/assets/96957774/9c6d9f5f-ea7e-48ae-9ab2-bfca14039f52)

최단 경로를 구했으니 이중에서 원래 원했던 K 거리만큼의 거리 내에 있는 모든 노드를 출력합니다.
