### PR TITLE
[BOJ] 1446_지름길 / 실버1 / 60분 / O

### DIFF
--- a/week9/BOJ_1446/지름길_홍지훈.py
+++ b/week9/BOJ_1446/지름길_홍지훈.py
@@ -1,0 +1,37 @@
+from heapq import heappush, heappop
+import sys
+input = sys.stdin.readline
+INF = 10000
+
+N, D = map(int,input().split()) # N : 지름길의 개수, D : 고속도로의 길이
+
+answer = {node: INF for node in range(D + 1)}
+
+graph = [[] for i in range(D + 1)]
+
+for i in range(D): 
+  for j in range(i + 1, D + 1):
+    graph[i].append((j, j - i))
+
+for _ in range(N):
+  start, end, dist = map(int, input().split())
+  if start < end and start < D: # 시작점이 목적지보다 큰 지름길이 주어질 수 있다.
+    graph[start].append((end, dist)) # start 에서 end 로 가는 지름길의 길이가 dist 이다.
+
+def dijkstra():
+  que = []
+  heappush(que, (0, 0))
+  answer[0] = 0
+  while que:
+    dist, now = heappop(que)
+    if answer[now] < dist or now > D:
+      continue
+    for next in graph[now]:
+      new_dist = dist + next[1]
+      if next[0] <= D and new_dist < answer[next[0]]:
+        answer[next[0]] = new_dist
+        heappush(que, (new_dist, next[0]))
+
+dijkstra()
+
+print(answer[D])


### PR DESCRIPTION
### 📖 풀이한 문제

- 백준 1446-지름길

### ⭐️ 문제에서 주로 사용한 알고리즘

`다익스트라`

### 대략적인 코드 설명

`주의점`

1. 지름길의 정보중 지름길의 목적지가 전체 길의 목적지보다 클 수도 있다.
2. 지름길의 시작보다 지름길의 목적지가 작거나 같을수도 있다.
3. 지름길의 시작점이 전체 길의 목적지보다 클수도 있다.

> 실행해보며 나중에 런타임 오류가 떠서 제외했던 예외사항들입니다..

마찬가지로 다익스트라 알고리즘을 사용했으나 dfs 같은 걸 써도 괜찮을 것 같다는 생각이 드는 문제였습니다.

- 노드를 위치마다 갖는 것으로 생각했습니다.
- 그래서 위치 0 와는 위치 1 ~ 위치 목적지 까지 연결된 경로가 존재하고, 위치 1은 위치 2 ~ 위치 목적지 까지 연결된 경로가 존재한다고 생각하고 초기화를 해주었습니다.

```py
from heapq import heappush, heappop
import sys
input = sys.stdin.readline
INF = 10000

N, D = map(int,input().split()) # N : 지름길의 개수, D : 고속도로의 길이

answer = {node: INF for node in range(D + 1)}

graph = [[] for i in range(D + 1)]

for i in range(D): 
  for j in range(i + 1, D + 1):
    graph[i].append((j, j - i)) # 위치 i 에서 j 로 가는 경로가 존재
```

- 그 다음에 지름길에 대한 입력을 주는데 이때 지름길의 시작점은 끝점보다 항상 작고, 시작점은 목적지 D 보다 작아야 한다는 조건을 걸었습니다.

```py
for _ in range(N):
  start, end, dist = map(int, input().split())
  if start < end and start < D: # 시작점이 목적지보다 큰 지름길이 주어질 수 있다.
    graph[start].append((end, dist)) # start 에서 end 로 가는 지름길의 길이가 dist 이다.
```

- 다익스트라 알고리즘은 이전 문제들과 동일하게 heap 을 사용하여 최단거리가 가장 짧은 노드를 선택할 수 있도록 했습니다.
- 결과적으로 D 까지 가는데 최단거리를 구하도록 했습니다.