### PR TITLE
[BOJ] 2503_숫자야구 / 실버3 / 60분 / O

### DIFF
--- a/week10/BOJ_2503/숫자 야구_홍지훈.py
+++ b/week10/BOJ_2503/숫자 야구_홍지훈.py
@@ -1,0 +1,42 @@
+import sys
+from itertools import permutations
+from collections import deque
+input = sys.stdin.readline
+
+N = int(input().rstrip()) # N : 질문 횟수
+
+nums = [1,2,3,4,5,6,7,8,9]
+
+def calc_strike(num1: str, target: str) -> int:
+  count = 0
+  for i in range(3):
+    if num1[i] == target[i]:
+      count += 1
+  return count
+
+def calc_ball(num1: str, target: str) -> int:
+  count = 0
+  for i in range(3):
+    if num1[i] != target[i] and num1[i] in target:
+      count += 1
+  return count
+
+target_list = deque([])
+for _ in range(N): 
+  ans, strike, ball = map(int, input().rstrip().split())
+  if not target_list: # 아직 후보군을 정하지 못한 초기라면
+    for tuple in list(permutations(nums, 3)): # 순열을 사용해 가능한 모든 후보군중 가능한 후보군을 선정합니다.
+      num = ''.join(map(str, tuple))
+
+      if calc_strike(str(ans), num) == strike and calc_ball(str(ans), num) == ball and num not in target_list: # 후보군중 스트라이크 수, 볼 수, 중복을 제외한 후보군으로 초기화합니다.
+        target_list.append(num)
+  else:
+    temp = list(target_list)
+    for tuple in target_list:
+      num = ''.join(map(str, tuple))
+
+      if calc_strike(str(ans), num) != strike or calc_ball(str(ans), num) != ball: # 두번째 질문부터 후보군중 조건을 만족하지 않는 후보를 제거합니다.
+        temp.remove(num)
+    target_list = deque(temp)
+
+print(len(target_list))


### PR DESCRIPTION
### 📖 풀이한 문제

- 백준 2503-숫자야구

### ⭐️ 문제에서 주로 사용한 알고리즘

`브루트포스`

### 대략적인 코드 설명

1. 먼저 스트라이크 수를 구하는 메서드와 볼의 개수를 구하는 메서드를 구했습니다.

```py
def calc_strike(num1: str, target: str) -> int:
  count = 0
  for i in range(3):
    if num1[i] == target[i]:
      count += 1
  return count

def calc_ball(num1: str, target: str) -> int:
  count = 0
  for i in range(3):
    if num1[i] != target[i] and num1[i] in target:
      count += 1
  return count
```

2. 접근 전략으로 민혁이가 질문할 때마다 후보 리스트를 갱신하자는 생각을 했습니다.

- 먼저 후보 리스트가 아무것도 없었을 때는 `permutation` 순열을 사용한 모든 후보리스트 중에서 민혁이가 처음 질문한 숫자와 비교할때 가능한 후보군을 초기 `target_list` 에 넣었습니다. 단, 중복된 값을 넣지 않도록 했습니다.

```py
ans, strike, ball = map(int, input().rstrip().split())
  if not target_list:
    for tuple in list(permutations(nums, 3)):
      num = ''.join(map(str, tuple))

      if calc_strike(str(ans), num) == strike and calc_ball(str(ans), num) == ball and num not in target_list:
        target_list.append(num)
```

- 첫 번째 질문 이후의 질문한 숫자들부턴 이미 구한 후보군 `target_list` 중에서 가능하지 않는 경우 후보군에서 제거하는 식으로 코드를 짰습니다. 

```py
temp = list(target_list)
    for tuple in target_list:
      num = ''.join(map(str, tuple))

      if calc_strike(str(ans), num) != strike or calc_ball(str(ans), num) != ball:
        temp.remove(num)
    target_list = deque(temp)
```

> x in a 를 O(1) 로 해주기 위해 deque 을 사용했습니다.