### PR TITLE
[BOJ] 1890_점프 / 실버1 / 40분 / O

### DIFF
--- a/week12/BOJ_1890/점프_홍지훈.py
+++ b/week12/BOJ_1890/점프_홍지훈.py
@@ -1,0 +1,26 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input().rstrip()) # N : 게임 판의 크기, 4 ~ 100
+dp = []
+
+for _ in range(N):
+  row = list(map(int, input().rstrip().split()))
+  dp.append([[val, 0] for val in row])
+
+def update(r, c, curr, start = False):
+    if curr + c < N: # col 방향 경로 존재할 때
+      dp[r][c + curr][1] = 1 if start else dp[r][c + curr][1] + dp[r][c][1]
+    if curr + r < N: # row 방향 경로 존재할 때
+      dp[r + curr][c][1] = 1 if start else dp[r + curr][c][1] + dp[r][c][1]
+
+for r in range(N):
+  for c in range(N):
+    curr = dp[r][c][0]
+    if r == 0 and c == 0:
+      update(r, c, curr, True)
+    elif r != N - 1 or c != N - 1:
+      if dp[r][c][1] != 0:
+        update(r, c, curr)
+
+print(dp[N-1][N-1][1])


### PR DESCRIPTION
### 📖 풀이한 문제

- 백준 1890-점프

### ⭐️ 문제에서 주로 사용한 알고리즘

`multidimensional dp`

### 대략적인 코드 설명

- dp 라는 2차원 행렬을 만들었고 각 셀마다 입력으로 받은 숫자와 지금까지 경로의 수를 갱신할 배열을 넣어주었습니다.

```py
import sys
input = sys.stdin.readline

N = int(input().rstrip()) # N : 게임 판의 크기, 4 ~ 100
dp = []

for _ in range(N):
  row = list(map(int, input().rstrip().split()))
  dp.append([[val, 0] for val in row])
```

- 경로의 수를 갱신할 update 라는 메서드를 생성했습니다. 이 메서드의 경우 맨 처음 (0,0) 일때는 다음 위치까지의 경로의 수를 1로 바꾸지만 그 외의 경우 다음 위치까지의 경로는 다음 위치까지의 경로와 현재 위치까지의 경로 수를 더해서 구하도록 했습니다.

```py
def update(r, c, curr, start = False):
    if curr + c < N: # col 방향 경로 존재할 때
      dp[r][c + curr][1] = 1 if start else dp[r][c + curr][1] + dp[r][c][1]
    if curr + r < N: # row 방향 경로 존재할 때
      dp[r + curr][c][1] = 1 if start else dp[r + curr][c][1] + dp[r][c][1]
```

- bottom-up 방식의 dp 접근법에 따라 0,0, 부터 N-1, N-1 까지 순회하며 N-1, N-1 은 이미 도착한 지점이라 제외하고 update 를 진행해주었습니다. 이때 처음 좌표와 그 외의 경우를 나누어 update 를 진행했습니다.

```py
for r in range(N):
  for c in range(N):
    curr = dp[r][c][0]
    if r == 0 and c == 0:
      update(r, c, curr, True)
    elif r != N - 1 or c != N - 1:
      if dp[r][c][1] != 0:
        update(r, c, curr)

print(dp[N-1][N-1][1])
```

### 비슷한 문제 추천

https://leetcode.com/problems/minimum-path-sum/description/

리트코드 64. Minimum Path Sum 이라는 문제로 이 문제의 경우 비슷하게 왼쪽 위에서 오른쪽 아래로 갈 때 지난는 경로상 숫자의 합이 최소가 되는 경우 최소합을 구하라는 문제입니다. 

이 문제처럼 다차원 dp 를 구하는 문제를 연습하고 싶으신 분들은 한번 풀어보셔도 좋을 것 같아요~!