### PR TITLE
[BOJ] 11724_연결 요소의 개수 / 실버1 / 10분 / O

### DIFF
--- a/week16/BOJ_11724/연결 요소의 개수_홍지훈.py
+++ b/week16/BOJ_11724/연결 요소의 개수_홍지훈.py
@@ -1,0 +1,29 @@
+import sys
+input = sys.stdin.readline
+from collections import deque
+
+N, M = map(int, input().rstrip().split()) # N: 정점의 개수, M: 간선의 개수
+pairs = [[] for _ in range(N + 1)]
+visited = [False for _ in range(N + 1)]
+for _ in range(M):
+  u, v = map(int, input().rstrip().split())
+  pairs[v].append(u)
+  pairs[u].append(v)
+
+def bfs(node: int) -> int:
+  visited[node] = True
+  q = deque([node])
+  while q:
+    cur = q.popleft()
+    for next in pairs[cur]:
+      if not visited[next]:
+        visited[next] = True
+        q.append(next)
+
+result = 0
+for key in range(1, N + 1):
+  if not visited[key]:
+    bfs(key)
+    result += 1
+
+print(result)


### PR DESCRIPTION
### 📖 풀이한 문제

- 백준 11724-연결 요소의 개수

### ⭐️ 문제에서 주로 사용한 알고리즘

`bfs`

### 대략적인 코드 설명

- 연결 리스트를 통해 bfs 를 사용해 풀이를 했습니다.
- 방향이 없는 연결 관계를 나타내주어서 양방향에 대해 정보를 pairs 라는 행렬에 넣어주고 방문 여부를 토대로 연결 요소의 개수를 카운트합니다.

/schedule