### PR TITLE
특정한 최단 경로 / 골드4 / 40분 / O

### DIFF
--- a/week22/BOJ_1504/특정한 최단 경로_홍지훈.py
+++ b/week22/BOJ_1504/특정한 최단 경로_홍지훈.py
@@ -1,0 +1,42 @@
+from heapq import heappush, heappop
+import sys
+input = sys.stdin.readline
+INF = int(1e9)
+
+N, E = map(int, input().split()) # N: 정점의 개수, E: 간선의 개수
+graph = [[] for i in range(N + 1)] # 연결 리스트 graph
+
+for _ in range(E):
+  a, b, c = map(int, input().split()) # a 번 정점에서 b 번 정점까지 양방향 길 존재, 거리가 c
+  graph[a].append((b, c))
+  graph[b].append((a, c))
+
+v1, v2 = map(int, input().split()) # v1, v2 는 반드시 거쳐야 하는 두 개의 서로 다른 정점
+
+def dijkstra(start):
+  que = []
+  answer = {node: INF for node in range(1, N + 1)} # 최단 거리를 기록할 answer
+  heappush(que, (0, start))
+  answer[start] = 0
+  while que:
+    dist, now = heappop(que)
+    if answer[now] < dist:
+      continue
+    for next in graph[now]:
+      new_dist = dist + next[1]
+      if new_dist < answer[next[0]]:
+        answer[next[0]] = new_dist
+        heappush(que, (new_dist, next[0]))
+  return answer
+
+'''
+1 -> v1 -> v2 -> N
+1 -> v2 -> v1 -> N
+caution! case1, case2 중 하나의 값이 INF 보다 커질수도 있습니다
+'''
+
+case1 = dijkstra(1)[v1] + dijkstra(v1)[v2] + dijkstra(v2)[N]
+case2 = dijkstra(1)[v2] + dijkstra(v2)[v1] + dijkstra(v1)[N]
+
+result = min(case1, case2)
+print(-1 if result >= INF else result)


### PR DESCRIPTION
### ⭐️ 문제에서 주로 사용한 알고리즘

`다익스트라`

### 대략적인 코드 설명

이번엔 다익스트라를 사용하되, 거리를 반영해줘야 하는 문제였습니다.
이전 다익스트라와 달리 거리라는 개념을 추가해주는 부분만 변경했습니다.

v1,v2 노드를 반드시 지나야 하니
1 -> v1 -> v2 -> N
혹은 
1 -> v2 -> v1 -> N 노드를 지나는 경우 2가지만 비교하면 됩니다.

<img width="828" alt="스크린샷 2024-03-24 오후 6 02 52" src="https://github.com/Stendhalsynd/baekjoon-algorithm-study/assets/96957774/bce6ec4c-600b-4cdc-a3d7-16b1c3e8adb5">

```py
case1 = dijkstra(1)[v1] + dijkstra(v1)[v2] + dijkstra(v2)[N]
case2 = dijkstra(1)[v2] + dijkstra(v2)[v1] + dijkstra(v1)[N]

result = min(case1, case2)
print(-1 if result >= INF else result)
```

v1, v2 가 연결된 그래프가 서로 끊어져있을 경우도 고려해야 합니다. ( case1, case2 모두 무한대보다 크거나 같을수 있습니다. )
그래서 result == INF 가 아닌 result >= INF 로 조건을 걸었습니다.

그래프 형태를 시각적으로 비교하는 사이트가 있던데 저장해두면 유용할 것 같습니다
https://csacademy.com/app/graph_editor/



### 코드리뷰시 요청사항
